### PR TITLE
Set viewport initial-scale to fix responsive views

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,6 +16,7 @@ const RootComponent: React.FC = ({ children }) => {
   return (
     <>
       <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png" />
         <link rel="apple-touch-icon" sizes="60x60" href="/apple-icon-60x60.png" />
         <link rel="apple-touch-icon" sizes="72x72" href="/apple-icon-72x72.png" />


### PR DESCRIPTION
Forces a reasonable zoom level, rather than zooming out to accomadate oversized content.